### PR TITLE
Fix strange artifact names for shadowJars on OS X otherwise

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,8 +86,10 @@ tasks.test {
     }
 }
 
-tasks.shadowJar.configure {
-    archiveFileName.set("$archiveBaseName-$archiveClassifier-$archiveVersion.jar")
+tasks.shadowJar {
+    archiveFileName.set(
+        "${archiveBaseName.get()}-${archiveClassifier.get()}-${archiveVersion.get()}.${archiveExtension.get()}"
+    )
 }
 
 publishing {


### PR DESCRIPTION
Since this change, the build artifact is named:

```
task ':shadowJar' property 'archiveBaseName'-task ':shadowJar' property 'archiveClassifier'-task ':shadowJar' property 'archiveVersion'.jar
```

I don't know why this happens, but I prefer the other file name: `jconstraints-all-XXX.jar` without whitespaces.