### PR TITLE
Add quantifier parsing support as proposed by @oxanaw

### DIFF
--- a/src/main/java/gov/nasa/jpf/constraints/expressions/LetExpression.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/LetExpression.java
@@ -24,6 +24,7 @@ import gov.nasa.jpf.constraints.api.ExpressionVisitor;
 import gov.nasa.jpf.constraints.api.Valuation;
 import gov.nasa.jpf.constraints.api.Variable;
 import gov.nasa.jpf.constraints.expressions.flattening.LetExpressionFlattenerVisitor;
+import gov.nasa.jpf.constraints.types.Type;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -141,5 +142,10 @@ public class LetExpression extends EqualityExpression {
   public Expression flattenLetExpression() {
     LetExpressionFlattenerVisitor v = new LetExpressionFlattenerVisitor();
     return accept(v, null);
+  }
+
+  @Override
+  public Type getType() {
+    return mainValue.getType();
   }
 }

--- a/src/main/java/gov/nasa/jpf/constraints/expressions/NumericCompound.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/NumericCompound.java
@@ -89,6 +89,8 @@ public class NumericCompound<E> extends AbstractExpression<E> {
         return type.div(lv, rv);
       case REM:
         return type.mod(lv, rv);
+      case MOD:
+        return type.mod(lv, rv);
       default:
         throw new IllegalStateException("Unknown numeric operator " + operator);
     }

--- a/src/main/java/gov/nasa/jpf/constraints/expressions/NumericOperator.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/NumericOperator.java
@@ -25,7 +25,8 @@ public enum NumericOperator implements ExpressionOperator {
   MUL("*"),
   MINUS("-"),
   PLUS("+"),
-  REM("%");
+  REM("%"),
+  MOD("MOD");
 
   private final String str;
 
@@ -39,7 +40,7 @@ public enum NumericOperator implements ExpressionOperator {
   }
 
   public static NumericOperator fromString(String str) {
-    switch (str) {
+    switch (str.toLowerCase()) {
       case "/":
         return DIV;
       case "*":
@@ -50,8 +51,11 @@ public enum NumericOperator implements ExpressionOperator {
       case "bvadd":
       case "+":
         return PLUS;
+      case "rem":
       case "%":
         return REM;
+      case "mod":
+        return MOD;
       default:
         return null;
     }

--- a/src/main/java/gov/nasa/jpf/constraints/expressions/QuantifierExpression.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/QuantifierExpression.java
@@ -186,4 +186,9 @@ public class QuantifierExpression extends AbstractBoolExpression {
   public <R, D> R accept(ExpressionVisitor<R, D> visitor, D data) {
     return visitor.visit(this, data);
   }
+
+  public static QuantifierExpression create(
+      Quantifier q, List<? extends Variable<?>> boundVariables, Expression<Boolean> body) {
+    return new QuantifierExpression(q, boundVariables, body);
+  }
 }

--- a/src/main/java/gov/nasa/jpf/constraints/expressions/StringCompoundExpression.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/StringCompoundExpression.java
@@ -75,6 +75,12 @@ public class StringCompoundExpression extends AbstractStringExpression {
         main, StringOperator.REPLACE, null, null, null, src, dst, null);
   }
 
+  public static StringCompoundExpression createReplaceAll(
+      Expression<?> main, Expression<?> src, Expression<?> dst) {
+    return new StringCompoundExpression(
+        main, StringOperator.REPLACEALL, null, null, null, src, dst, null);
+  }
+
   public static StringCompoundExpression createToLower(Expression<?> main) {
     return new StringCompoundExpression(
         main, StringOperator.TOLOWERCASE, null, null, null, null, null, null);

--- a/src/main/java/gov/nasa/jpf/constraints/expressions/StringOperator.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/StringOperator.java
@@ -25,6 +25,7 @@ public enum StringOperator implements ExpressionOperator {
   AT("str.at"),
   TOSTR("int.to.str"),
   REPLACE("str.replace"),
+  REPLACEALL("str.replaceall"),
   TOLOWERCASE("str.lower"),
   TOUPPERCASE("str.upper");
 
@@ -51,6 +52,8 @@ public enum StringOperator implements ExpressionOperator {
         return TOSTR;
       case "str.replace":
         return REPLACE;
+      case "str.replaceall":
+        return REPLACEALL;
       case "str.lower":
         return TOLOWERCASE;
       case "str.upper":

--- a/src/main/java/gov/nasa/jpf/constraints/expressions/flattening/LetExpressionFlattenerVisitor.java
+++ b/src/main/java/gov/nasa/jpf/constraints/expressions/flattening/LetExpressionFlattenerVisitor.java
@@ -20,17 +20,24 @@
 package gov.nasa.jpf.constraints.expressions.flattening;
 
 import gov.nasa.jpf.constraints.api.Expression;
+import gov.nasa.jpf.constraints.api.Variable;
 import gov.nasa.jpf.constraints.expressions.LetExpression;
 import gov.nasa.jpf.constraints.simplifiers.datastructures.ArithmeticVarReplacements;
 import gov.nasa.jpf.constraints.util.DuplicatingVisitor;
 import gov.nasa.jpf.constraints.util.ExpressionUtil;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class LetExpressionFlattenerVisitor extends DuplicatingVisitor<Void> {
 
   @Override
   public Expression<?> visit(LetExpression let, Void data) {
     Expression visitedMain = visit(let.getMainValue(), data);
-    return ExpressionUtil.transformVars(
-        visitedMain, new ArithmeticVarReplacements(let.getParameterValues()));
+    Map<Variable, Expression> m = new HashMap<>();
+    for (Entry<Variable, Expression> e : let.getParameterValues().entrySet()) {
+      m.put(e.getKey(), visit(e.getValue(), data));
+    }
+    return ExpressionUtil.transformVars(visitedMain, new ArithmeticVarReplacements(m));
   }
 }

--- a/src/main/java/gov/nasa/jpf/constraints/smtlibUtility/parser/SMTLIBParser.java
+++ b/src/main/java/gov/nasa/jpf/constraints/smtlibUtility/parser/SMTLIBParser.java
@@ -466,6 +466,9 @@ public class SMTLIBParser {
         case REPLACE:
           return StringCompoundExpression.createReplace(
               arguments.poll(), arguments.poll(), arguments.poll());
+        case REPLACEALL:
+          return StringCompoundExpression.createReplaceAll(
+              arguments.poll(), arguments.poll(), arguments.poll());
         case SUBSTR:
           return StringCompoundExpression.createSubstring(
               arguments.poll(), arguments.poll(), arguments.poll());

--- a/src/main/java/gov/nasa/jpf/constraints/types/BuiltinTypes.java
+++ b/src/main/java/gov/nasa/jpf/constraints/types/BuiltinTypes.java
@@ -158,8 +158,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Byte mod(final Byte left, final Byte right) {
+    public Byte rem(final Byte left, final Byte right) {
       return (byte) (left % right);
+    }
+
+    @Override
+    public Byte mod(Byte left, Byte right) {
+      return (byte) Math.floorMod(left, right);
     }
 
     @Override
@@ -251,8 +256,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Short mod(final Short left, final Short right) {
+    public Short rem(final Short left, final Short right) {
       return (short) (left % right);
+    }
+
+    @Override
+    public Short mod(Short left, Short right) {
+      return (short) Math.floorMod(left, right);
     }
 
     @Override
@@ -379,8 +389,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Character mod(final Character left, final Character right) {
+    public Character rem(final Character left, final Character right) {
       return (char) (left % right);
+    }
+
+    @Override
+    public Character mod(Character left, Character right) {
+      throw new UnsupportedOperationException("Cannot compute mod for char");
     }
 
     @Override
@@ -539,8 +554,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Integer mod(final Integer left, final Integer right) {
+    public Integer rem(final Integer left, final Integer right) {
       return left % right;
+    }
+
+    @Override
+    public Integer mod(Integer left, Integer right) {
+      return Math.floorMod(left, right);
     }
 
     @Override
@@ -652,8 +672,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Long mod(final Long left, final Long right) {
+    public Long rem(final Long left, final Long right) {
       return left % right;
+    }
+
+    @Override
+    public Long mod(Long left, Long right) {
+      return Math.floorMod(left, right);
     }
 
     @Override
@@ -750,8 +775,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Float mod(final Float left, final Float right) {
+    public Float rem(final Float left, final Float right) {
       return left % right;
+    }
+
+    @Override
+    public Float mod(Float left, Float right) {
+      throw new UnsupportedOperationException("Cannot compute mod for float");
     }
 
     @Override
@@ -841,8 +871,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public Double mod(final Double left, final Double right) {
+    public Double rem(final Double left, final Double right) {
       return left % right;
+    }
+
+    @Override
+    public Double mod(Double left, Double right) {
+      throw new UnsupportedOperationException("Cannot compute mod for double");
     }
 
     @Override
@@ -917,8 +952,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public BigInteger mod(final BigInteger left, final BigInteger right) {
+    public BigInteger rem(final BigInteger left, final BigInteger right) {
       return left.remainder(right);
+    }
+
+    @Override
+    public BigInteger mod(BigInteger left, BigInteger right) {
+      return left.mod(right);
     }
 
     @Override
@@ -999,8 +1039,13 @@ public abstract class BuiltinTypes implements Serializable {
     }
 
     @Override
-    public BigDecimal mod(final BigDecimal left, final BigDecimal right) {
+    public BigDecimal rem(final BigDecimal left, final BigDecimal right) {
       return left.remainder(right);
+    }
+
+    @Override
+    public BigDecimal mod(BigDecimal left, BigDecimal right) {
+      throw new UnsupportedOperationException("Cannot compute mod for REAL");
     }
 
     @Override
@@ -1121,6 +1166,11 @@ public abstract class BuiltinTypes implements Serializable {
 
     @Override
     public BigFraction mod(BigFraction left, BigFraction right) {
+      throw new UnsupportedOperationException("Modulo is not yet supported on RealValues");
+    }
+
+    @Override
+    public BigFraction rem(BigFraction left, BigFraction right) {
       throw new UnsupportedOperationException("Remainder is not yet supported on RealValues");
     }
 

--- a/src/main/java/gov/nasa/jpf/constraints/types/NumericType.java
+++ b/src/main/java/gov/nasa/jpf/constraints/types/NumericType.java
@@ -41,6 +41,8 @@ public interface NumericType<T> extends Type<T> {
 
   public T div(T left, T right);
 
+  public T rem(T left, T right);
+
   public T mod(T left, T right);
 
   public T negate(T num);

--- a/src/main/java/gov/nasa/jpf/constraints/util/DuplicatingVisitor.java
+++ b/src/main/java/gov/nasa/jpf/constraints/util/DuplicatingVisitor.java
@@ -21,8 +21,17 @@ package gov.nasa.jpf.constraints.util;
 
 import gov.nasa.jpf.constraints.api.Expression;
 import gov.nasa.jpf.constraints.expressions.AbstractExpressionVisitor;
+import gov.nasa.jpf.constraints.expressions.IfThenElse;
 
 public abstract class DuplicatingVisitor<D> extends AbstractExpressionVisitor<Expression<?>, D> {
+
+  @Override
+  public <E> Expression<?> visit(IfThenElse<E> n, D data) {
+    Expression conditionE = visit(n.getIf(), data);
+    Expression thenE = visit(n.getThen(), data);
+    Expression elseE = visit(n.getElse(), data);
+    return IfThenElse.create(conditionE, thenE, elseE);
+  }
 
   /* (non-Javadoc)
    * @see gov.nasa.jpf.constraints.api.AbstractExpressionVisitor#defaultVisit(gov.nasa.jpf.constraints.api.Expression, java.lang.Object)

--- a/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
+++ b/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
@@ -92,8 +92,7 @@ public class LetExpressionTest {
     NumericBooleanExpression replacementB = NumericBooleanExpression.create(x4, GT, c2);
     LetExpression let2 = LetExpression.create(x3, replacementB, expr2);
 
-    Expression expectedOutcome2 =
-        PropositionalCompound.create(replacementB, AND, expectedOutcome);
+    Expression expectedOutcome2 = PropositionalCompound.create(replacementB, AND, expectedOutcome);
 
     System.out.println(let2);
     System.out.println(let2.flattenLetExpression());
@@ -173,8 +172,8 @@ public class LetExpressionTest {
     IfThenElse ite2 = IfThenElse.create(B2, X1, LetX1);
     IfThenElse ite3 = IfThenElse.create(B3, X2, X3);
     IfThenElse ite4 = IfThenElse.create(B4, X4, LetX2);
-    LetExpression let1 = LetExpression
-        .create(LetX4, PropositionalCompound.create(LetX3, AND, LetX5), LetX4);
+    LetExpression let1 =
+        LetExpression.create(LetX4, PropositionalCompound.create(LetX3, AND, LetX5), LetX4);
     LetExpression let2 = LetExpression.create(LetX3, ite4, let1);
     LetExpression let3 = LetExpression.create(LetX2, ite3, let2);
     LetExpression let4 = LetExpression.create(LetX5, ite2, let3);
@@ -188,7 +187,6 @@ public class LetExpressionTest {
     assertFalse(vars.contains(LetX4));
     assertFalse(vars.contains(LetX5));
   }
-
 
   public class DummyVisitorForTest extends AbstractExpressionVisitor<Expression, Boolean> {
 

--- a/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
+++ b/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
@@ -114,6 +114,24 @@ public class LetExpressionTest {
     assertTrue(vars.contains(x4), "The x4 is very present now");
   }
 
+  @Test(groups = {"expressions", "base"})
+  public void chainedLetExpressionFlattening02Test() {
+    Variable y = Variable.create(BuiltinTypes.SINT32, "Y");
+
+    NumericCompound nc = NumericCompound.create(x, NumericOperator.PLUS, c4);
+    NumericBooleanExpression nbe = NumericBooleanExpression.create(x1, EQ, x2);
+    LetExpression inner2 = LetExpression.create(y, nc, y);
+    LetExpression inner = LetExpression.create(x1, inner2, nbe);
+    Variable x4 = Variable.create(BuiltinTypes.SINT32, "x4");
+    LetExpression outter = LetExpression.create(x, x4, inner);
+    Expression flattened = outter.flattenLetExpression();
+    Set<Variable<?>> vars = ExpressionUtil.freeVariables(flattened);
+    assertFalse(vars.contains(x), "the x should be replaced by x4");
+    assertFalse(vars.contains(x1), "The x1 should be replaced by the numeric compound");
+    assertFalse(vars.contains(y), "The y should be replaced by the numeric compound");
+    assertTrue(vars.contains(x4), "The x4 is very present now");
+  }
+
   public class DummyVisitorForTest extends AbstractExpressionVisitor<Expression, Boolean> {
 
     @Override

--- a/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
+++ b/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
@@ -20,6 +20,7 @@
 package gov.nasa.jpf.constraints.expressions;
 
 import static gov.nasa.jpf.constraints.expressions.NumericComparator.EQ;
+import static gov.nasa.jpf.constraints.expressions.NumericComparator.GT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -38,7 +39,7 @@ public class LetExpressionTest {
   Variable x1 = Variable.create(BuiltinTypes.SINT32, "x1");
   Variable x2 = Variable.create(BuiltinTypes.SINT32, "x2");
   Constant c = Constant.create(BuiltinTypes.SINT32, 5);
-  Expression<Boolean> expr = NumericBooleanExpression.create(x, NumericComparator.GT, c);
+  Expression<Boolean> expr = NumericBooleanExpression.create(x, GT, c);
   Constant c4 = Constant.create(BuiltinTypes.SINT32, 4);
   LetExpression letExpr = LetExpression.create(x, c4, expr);
 
@@ -66,7 +67,7 @@ public class LetExpressionTest {
 
   @Test(groups = {"expressions", "base"})
   public void flattenLetExpression1Test() {
-    Expression expectedOutcome = NumericBooleanExpression.create(c4, NumericComparator.GT, c);
+    Expression expectedOutcome = NumericBooleanExpression.create(c4, GT, c);
     assertEquals(letExpr.flattenLetExpression(), expectedOutcome);
   }
 
@@ -87,8 +88,7 @@ public class LetExpressionTest {
     Expression expr2 = PropositionalCompound.create(x3, LogicalOperator.AND, expr);
 
     Variable x4 = Variable.create(BuiltinTypes.SINT32, "x4");
-    NumericBooleanExpression replacementB =
-        NumericBooleanExpression.create(x4, NumericComparator.GT, c2);
+    NumericBooleanExpression replacementB = NumericBooleanExpression.create(x4, GT, c2);
     LetExpression let2 = LetExpression.create(x3, replacementB, expr2);
 
     Expression expectedOutcome2 =
@@ -130,6 +130,20 @@ public class LetExpressionTest {
     assertFalse(vars.contains(x1), "The x1 should be replaced by the numeric compound");
     assertFalse(vars.contains(y), "The y should be replaced by the numeric compound");
     assertTrue(vars.contains(x4), "The x4 is very present now");
+  }
+
+  @Test(groups = {"expressions", "base"})
+  public void letExpresisonsAndITE01Test() {
+    Variable X = Variable.create(BuiltinTypes.SINT32, "X");
+    Variable X1 = Variable.create(BuiltinTypes.SINT32, "X1");
+    Variable B = Variable.create(BuiltinTypes.BOOL, "B");
+    Constant c1 = Constant.create(BuiltinTypes.SINT32, 5);
+    IfThenElse ite = IfThenElse.create(B, X1, c1);
+    NumericBooleanExpression nbe =
+        NumericBooleanExpression.create(ite, GT, Constant.create(BuiltinTypes.SINT32, 6));
+    LetExpression let = LetExpression.create(X1, X, nbe);
+    Expression flat = let.flattenLetExpression();
+    assertFalse(flat.toString().contains("X1"), "X1 should be replaced");
   }
 
   public class DummyVisitorForTest extends AbstractExpressionVisitor<Expression, Boolean> {

--- a/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
+++ b/src/test/java/gov/nasa/jpf/constraints/expressions/LetExpressionTest.java
@@ -19,6 +19,7 @@
 
 package gov.nasa.jpf.constraints.expressions;
 
+import static gov.nasa.jpf.constraints.expressions.LogicalOperator.AND;
 import static gov.nasa.jpf.constraints.expressions.NumericComparator.EQ;
 import static gov.nasa.jpf.constraints.expressions.NumericComparator.GT;
 import static org.testng.Assert.assertEquals;
@@ -85,14 +86,14 @@ public class LetExpressionTest {
     assertEquals(expr.flattenLetExpression(), expectedOutcome);
 
     Variable x3 = Variable.create(BuiltinTypes.BOOL, "x3");
-    Expression expr2 = PropositionalCompound.create(x3, LogicalOperator.AND, expr);
+    Expression expr2 = PropositionalCompound.create(x3, AND, expr);
 
     Variable x4 = Variable.create(BuiltinTypes.SINT32, "x4");
     NumericBooleanExpression replacementB = NumericBooleanExpression.create(x4, GT, c2);
     LetExpression let2 = LetExpression.create(x3, replacementB, expr2);
 
     Expression expectedOutcome2 =
-        PropositionalCompound.create(replacementB, LogicalOperator.AND, expectedOutcome);
+        PropositionalCompound.create(replacementB, AND, expectedOutcome);
 
     System.out.println(let2);
     System.out.println(let2.flattenLetExpression());
@@ -145,6 +146,49 @@ public class LetExpressionTest {
     Expression flat = let.flattenLetExpression();
     assertFalse(flat.toString().contains("X1"), "X1 should be replaced");
   }
+
+  @Test(groups = {"expressions", "base"})
+  public void letExpresisonsAndITE02Test() {
+    Variable X = Variable.create(BuiltinTypes.BOOL, "X");
+    Variable X1 = Variable.create(BuiltinTypes.BOOL, "X1");
+    Variable X2 = Variable.create(BuiltinTypes.BOOL, "X2");
+    Variable X3 = Variable.create(BuiltinTypes.BOOL, "X3");
+    Variable X4 = Variable.create(BuiltinTypes.BOOL, "X4");
+    Variable X5 = Variable.create(BuiltinTypes.BOOL, "X5");
+    Variable X6 = Variable.create(BuiltinTypes.BOOL, "X6");
+    Variable X7 = Variable.create(BuiltinTypes.BOOL, "X7");
+    Variable X8 = Variable.create(BuiltinTypes.BOOL, "X8");
+    Variable B = Variable.create(BuiltinTypes.BOOL, "B");
+    Variable B2 = Variable.create(BuiltinTypes.BOOL, "B2");
+    Variable B3 = Variable.create(BuiltinTypes.BOOL, "B3");
+    Variable B4 = Variable.create(BuiltinTypes.BOOL, "B4");
+    Variable B5 = Variable.create(BuiltinTypes.BOOL, "B5");
+    Variable LetX1 = Variable.create(BuiltinTypes.BOOL, "LetX1");
+    Variable LetX2 = Variable.create(BuiltinTypes.BOOL, "?LetX2");
+    Variable LetX3 = Variable.create(BuiltinTypes.BOOL, "?LetX1");
+    Variable LetX4 = Variable.create(BuiltinTypes.BOOL, "$xLetX1");
+    Variable LetX5 = Variable.create(BuiltinTypes.BOOL, "$xLetX5");
+
+    IfThenElse ite = IfThenElse.create(B, X1, X);
+    IfThenElse ite2 = IfThenElse.create(B2, X1, LetX1);
+    IfThenElse ite3 = IfThenElse.create(B3, X2, X3);
+    IfThenElse ite4 = IfThenElse.create(B4, X4, LetX2);
+    LetExpression let1 = LetExpression
+        .create(LetX4, PropositionalCompound.create(LetX3, AND, LetX5), LetX4);
+    LetExpression let2 = LetExpression.create(LetX3, ite4, let1);
+    LetExpression let3 = LetExpression.create(LetX2, ite3, let2);
+    LetExpression let4 = LetExpression.create(LetX5, ite2, let3);
+    LetExpression let5 = LetExpression.create(LetX1, ite, let4);
+
+    Expression flat = let5.flattenLetExpression();
+    Set<Variable<?>> vars = ExpressionUtil.freeVariables(flat);
+    assertFalse(vars.contains(LetX1));
+    assertFalse(vars.contains(LetX2));
+    assertFalse(vars.contains(LetX3));
+    assertFalse(vars.contains(LetX4));
+    assertFalse(vars.contains(LetX5));
+  }
+
 
   public class DummyVisitorForTest extends AbstractExpressionVisitor<Expression, Boolean> {
 

--- a/src/test/java/gov/nasa/jpf/constraints/smtlibUtility/parser/SMTLIBParserTest.java
+++ b/src/test/java/gov/nasa/jpf/constraints/smtlibUtility/parser/SMTLIBParserTest.java
@@ -259,4 +259,16 @@ public class SMTLIBParserTest {
     assertEquals(problem.variables.size(), 4);
     assertEquals(problem.assertions.size(), 3);
   }
+
+  @Test(
+      enabled = true,
+      groups = {"jsmtlib", "base"})
+  public void operatorMod01Test()
+      throws SMTLIBParserException, IParser.ParserException, IOException {
+    final SMTProblem problem =
+        parseResourceFile("2008_5735c9082c3f9cd487c6376032029bb499ba1f87113dc9ca03adc6bc.smt2");
+
+    assertEquals(problem.variables.size(), 1);
+    assertEquals(problem.assertions.size(), 1);
+  }
 }

--- a/src/test/resources/2008_5735c9082c3f9cd487c6376032029bb499ba1f87113dc9ca03adc6bc.smt2
+++ b/src/test/resources/2008_5735c9082c3f9cd487c6376032029bb499ba1f87113dc9ca03adc6bc.smt2
@@ -1,0 +1,13 @@
+
+(declare-fun K () Int)
+
+(assert (and (not (not (= (ite (< (mod 7 K) 7) 1 0) 0))) (not (not (= (ite (= (mod 7 K) 0) 1 0) 0)))))
+
+(check-sat)
+
+;(get-value (K))
+
+
+
+
+


### PR DESCRIPTION
@oxanaw has included support for parsing quantified expressions in the SMT-Lib parser frontend connection of jConstraints. While the normalization utils are still work in progress, we will merge the quantifier parsing code in upfront.