### PR TITLE
Update guava version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ repositories {
 
 dependencies {
     antlr("org.antlr:antlr:3.5.2")
-    implementation("com.google.guava:guava:14.0.1")
+    implementation("com.google.guava:guava:30.1-jre")
     implementation("com.github.tudo-aqua:jSMTLIB:5c11ee5")
     implementation("commons-cli:commons-cli:1.4")
     implementation("dk.brics:automaton:1.12-1")


### PR DESCRIPTION
It seems safe to upgrade this dependency to a current version.