### PR TITLE
Update gradle workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,11 +7,8 @@ on:
     branches: [ master, develop ]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+  licenseAndFormatCheck:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.11
@@ -24,5 +21,17 @@ jobs:
       run: ./gradlew checkLicenses
     - name: Check formating
       run: ./gradlew verifyGoogleJavaFormat
+  build:
+    needs: licenseAndFormatCheck
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
     - name: Build with Gradle
       run: ./gradlew assemble test


### PR DESCRIPTION
There is no need to check formatting and license three times. It is sufficient and more economic, if
we do it once