### PR TITLE
Fix a memory leak in the Z3 binding.

### DIFF
--- a/jconstraints-z3/src/main/java/gov/nasa/jpf/constraints/solvers/nativez3/NativeZ3Solver.java
+++ b/jconstraints-z3/src/main/java/gov/nasa/jpf/constraints/solvers/nativez3/NativeZ3Solver.java
@@ -96,7 +96,7 @@ public class NativeZ3Solver extends ConstraintSolver
   public void dispose() {
     defaultContext.dispose();
     defaultContext = null;
-    // ctx.dispose();
+    ctx.close();
     ctx = null;
   }
 


### PR DESCRIPTION
This replaces a commented out memory-managent statement with a working one. This does not appear to break anything, but stops `libz3` from consuming all available memory when confronted by a very large number of problems.